### PR TITLE
Size movement calculation

### DIFF
--- a/script/common/actor.js
+++ b/script/common/actor.js
@@ -149,11 +149,12 @@ export class DarkHeresyActor extends Actor {
 
     _computeMovement(data) {
         let agility = data.data.characteristics.agility;
+        let size = data.data.size;
         data.data.movement = {
-            half: agility.bonus,
-            full: agility.bonus * 2,
-            charge: agility.bonus * 3,
-            run: agility.bonus * 6
+            half: agility.bonus + (size - 4),
+            full: (agility.bonus * 2) + (size - 4),
+            charge: (agility.bonus * 3) + (size - 4),
+            run: (agility.bonus * 6) + (size - 4)
         }
     }
 


### PR DESCRIPTION
Changing Size in the actor should adjust the base movement ratios.

![image](https://user-images.githubusercontent.com/27952699/103229936-6960a300-4934-11eb-91f4-9830b6ab7ec2.png)

Issue: https://github.com/moo-man/DarkHeresy2E-FoundryVTT/issues/10