### PR TITLE
Consider size into movement calculation

### DIFF
--- a/script/common/actor.js
+++ b/script/common/actor.js
@@ -149,11 +149,12 @@ export class DarkHeresyActor extends Actor {
 
     _computeMovement(data) {
         let agility = data.data.characteristics.agility;
+        let size = data.data.size;
         data.data.movement = {
-            half: agility.bonus,
-            full: agility.bonus * 2,
-            charge: agility.bonus * 3,
-            run: agility.bonus * 6
+            half: agility.bonus + (size - 4),
+            full: (agility.bonus * 2) + (size - 4),
+            charge: (agility.bonus * 3) + (size - 4),
+            run: (agility.bonus * 6) + (size - 4)
         }
     }
 


### PR DESCRIPTION
The default value is 4 and comes in the sheets:
![image](https://user-images.githubusercontent.com/27952699/103228438-2224e300-4931-11eb-98bd-b5250d34363b.png)

But movement is read only

![image](https://user-images.githubusercontent.com/27952699/103228409-10434000-4931-11eb-836b-2f19f069944c.png)

PS. I did a bit of a mess with branches, this should be fine.