### PR TITLE
Fixed wrong damagetype expressed in chat due to nested call

### DIFF
--- a/script/common/handlebars.js
+++ b/script/common/handlebars.js
@@ -124,9 +124,9 @@ function registerHandlebarsHelpers() {
         return game.i18n.localize("WEAPON.MELEE");
     }
   });
-  Handlebars.registerHelper("damageType", function (weaponClass) {
-    weaponClass = normalize(weaponClass, "melee");
-    switch (weaponClass) {
+  Handlebars.registerHelper("damageType", function (damageType) {
+    damageType = normalize(damageType, "impact");
+    switch (damageType) {
       case "energy":
         return game.i18n.localize("DAMAGE_TYPE.ENERGY_SHORT");
       case "impact":

--- a/template/chat/roll.html
+++ b/template/chat/roll.html
@@ -27,7 +27,7 @@
         {{/if}}
         {{#each damages as |damage|}}
             <h3 class="separator">{{localize location}}</h3>
-            <p><strong>{{localize "CHAT.DAMAGE"}}:</strong> {{damage.total}} <strong>{{damageType damageType}}</strong></p>
+            <p><strong>{{localize "CHAT.DAMAGE"}}:</strong> {{damage.total}} <strong>{{damageType ../damageType}}</strong></p>
             <p><strong>{{localize "CHAT.PENETRATION"}}:</strong> {{penetration}}</p>
             {{#if damage.righteousFury}}
             <p><strong>{{localize "CHAT.RIGHTEOUS_FURY"}}:</strong> {{damage.righteousFury}}</p>


### PR DESCRIPTION
Damage Type should now reflect correctly in the chat (previously showing always I for Impact)

![image](https://user-images.githubusercontent.com/27952699/103245158-90809a00-495f-11eb-9f5c-2c9e8ad70a95.png)
