### PR TITLE
Limited permissions to hide all sensible information except Notes

### DIFF
--- a/template/sheet/acolyte.html
+++ b/template/sheet/acolyte.html
@@ -47,12 +47,14 @@
         </div>
 
         <div class="sheet-tabs tabs flex row" data-group="primary">
+            {{#unless limited}}
             <b class="item" data-tab="stats">{{localize "TAB.STATS"}}</b>
             <b class="item" data-tab="combat">{{localize "TAB.COMBAT"}}</b>
             <b class="item" data-tab="abilities">{{localize "TAB.ABILITIES"}}</b>
             <b class="item" data-tab="psychic-powers">{{localize "TAB.PSYCHIC_POWERS"}}</b>
             <b class="item" data-tab="gear">{{localize "TAB.GEAR"}}</b>
             <b class="item" data-tab="progression">{{localize "TAB.ADVANCES"}}</b>
+            {{/unless}}
             <b class="item" data-tab="notes">{{localize "TAB.NOTES"}}</b>
         </div>
 

--- a/template/sheet/npc.html
+++ b/template/sheet/npc.html
@@ -10,6 +10,7 @@
                         <label>{{localize "BIO.NAME"}}</label>
                         <input name="name" type="text" value="{{actor.name}}" />
                     </div>
+                    {{#unless limited}}
                     <div class="header-row" style="height: 22px">
                         <div class="type">
                             <label>{{localize "BIO.TYPE"}}</label>
@@ -48,17 +49,20 @@
                             <input name="data.fatigue.max" type="number" value="{{data.fatigue.max}}" data-dtype="Number" />
                         </div>
                     </div>
+                    {{/unless}}
                 </div>
             </div>
         </div>
 
         <div class="sheet-tabs tabs flex row" data-group="primary">
+            {{#unless limited}}
             <b class="item" data-tab="stats">{{localize "TAB.STATS"}}</b>
             <b class="item" data-tab="combat">{{localize "TAB.COMBAT"}}</b>
             <b class="item" data-tab="abilities">{{localize "TAB.ABILITIES"}}</b>
             <b class="item" data-tab="psychic-powers">{{localize "TAB.PSYCHIC_POWERS"}}</b>
             <b class="item" data-tab="gear">{{localize "TAB.GEAR"}}</b>
             <b class="item" data-tab="progression">{{localize "TAB.ADVANCES"}}</b>
+            {{/unless}}
             <b class="item" data-tab="notes">{{localize "TAB.NOTES"}}</b>
         </div>
 


### PR DESCRIPTION
limits npcs to show name and notes, and acolyte actors to show the entire header and notes bar

**Note:** Acolyte type Actors and NPC type actors show different information.
Below is the NPC Actor type:
![image](https://user-images.githubusercontent.com/27952699/104294018-fa9c5180-54be-11eb-8b70-7bb397ec3fda.png)
