### PR TITLE
Adds apply damage macro - Issue #1

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -122,6 +122,7 @@
   "CHAT.PSY_PUSH": "Push",
   "CHAT.NUMBER_OF_HIT": "Number of Hit",
   "CHAT.HAS_PSYCHIC_PHENOMENA": "You must roll on the Psychic Phenomena table !",
+  "CHAT.CONTEXT.APPLY_DAMAGE": "Apply Damage",
 
   "CORRUPTION.HEADER": "Corruption",
   "CORRUPTION.MALIGNANCY": "Malignancy",

--- a/script/common/chat.js
+++ b/script/common/chat.js
@@ -36,6 +36,7 @@ function applyChatCardDamage(roll, multiplier) {
     const amount = roll.find('.damage-total')
     const location = roll.find('.damage-location')
     const penetration = roll.find('.damage-penetration')
+    const type = roll.find('.damage-type')
     const righteousFury = roll.find('.damage-righteous-fury')
 
     // put the data from different hits together
@@ -43,8 +44,9 @@ function applyChatCardDamage(roll, multiplier) {
     for (let i = 0; i < amount.length; i++) {
         damages.push({
             amount: $(amount[i]).text(),
-            location: $(location[i]).text(),
+            location: $(location[i]).data("location"),
             penetration: $(penetration[i]).text(),
+            type: $(type[i]).text(),
             righteousFury: $(righteousFury[i]).text(),
         })
     }

--- a/script/common/chat.js
+++ b/script/common/chat.js
@@ -1,0 +1,57 @@
+/**
+ * This function is used to hook into the Chat Log context menu to add additional options to each message
+ * These options make it easy to conveniently apply damage to controlled tokens based on the value of a Roll
+ *
+ * @param {HTMLElement} html    The Chat Message being rendered
+ * @param {Array} options       The Array of Context Menu options
+ *
+ * @return {Array}              The extended options Array including new context choices
+ */
+export const addChatMessageContextOptions = function (html, options) {
+    let canApply = li => {
+        const message = game.messages.get(li.data("messageId"));
+        return message.isRoll && message.isContentVisible && canvas.tokens.controlled.length;
+    };
+    options.push(
+        {
+            name: game.i18n.localize("CHAT.CONTEXT.APPLY_DAMAGE"),
+            icon: '<i class="fas fa-user-minus"></i>',
+            condition: canApply,
+            callback: li => applyChatCardDamage(li)
+        }
+    );
+    return options;
+};
+
+/**
+ * Apply rolled dice damage to the token or tokens which are currently controlled.
+ * This allows for damage to be scaled by a multiplier to account for healing, critical hits, or resistance
+ *
+ * @param {HTMLElement} roll    The chat entry which contains the roll data
+ * @param {Number} multiplier   A damage multiplier to apply to the rolled damage.
+ * @return {Promise}
+ */
+function applyChatCardDamage(roll, multiplier) {
+    // get the damage data, get them as arrays in case of multiple hits
+    const amount = roll.find('.damage-total')
+    const location = roll.find('.damage-location')
+    const penetration = roll.find('.damage-penetration')
+    const righteousFury = roll.find('.damage-righteous-fury')
+
+    // put the data from different hits together
+    const damages = []
+    for (let i = 0; i < amount.length; i++) {
+        damages.push({
+            amount: $(amount[i]).text(),
+            location: $(location[i]).text(),
+            penetration: $(penetration[i]).text(),
+            righteousFury: $(righteousFury[i]).text(),
+        })
+    }
+
+    // apply to any selected actors
+    return Promise.all(canvas.tokens.controlled.map(t => {
+        const a = t.actor;
+        return a.applyDamage(damages);
+    }));
+}

--- a/script/common/handlebars.js
+++ b/script/common/handlebars.js
@@ -44,6 +44,7 @@ function preloadHandlebarsTemplates() {
     "systems/dark-heresy/template/sheet/characteristics/total.html",
     "systems/dark-heresy/template/chat/item.html",
     "systems/dark-heresy/template/chat/roll.html",
+    "systems/dark-heresy/template/chat/critical.html",
     "systems/dark-heresy/template/dialog/common-roll.html",
     "systems/dark-heresy/template/dialog/combat-roll.html",
     "systems/dark-heresy/template/dialog/psychic-power-roll.html"
@@ -146,6 +147,21 @@ function registerHandlebarsHelpers() {
         return game.i18n.localize("DAMAGE_TYPE.EXPLOSIVE_SHORT");
       default:
         return game.i18n.localize("DAMAGE_TYPE.IMPACT_SHORT");
+    }
+  });
+  Handlebars.registerHelper("damageTypeLong", function (damageType) {
+    damageType = normalize(damageType, "i");
+    switch (damageType) {
+      case "e":
+        return game.i18n.localize("DAMAGE_TYPE.ENERGY");
+      case "i":
+        return game.i18n.localize("DAMAGE_TYPE.IMPACT");
+      case "r":
+        return game.i18n.localize("DAMAGE_TYPE.RENDING");
+      case "e":
+        return game.i18n.localize("DAMAGE_TYPE.EXPLOSIVE");
+      default:
+        return game.i18n.localize("DAMAGE_TYPE.IMPACT");
     }
   });
   Handlebars.registerHelper("craftsmanship", function (craftsmanship) {

--- a/script/common/hooks.js
+++ b/script/common/hooks.js
@@ -25,6 +25,9 @@ import { migrateWorld } from "./migration.js";
 import { prepareCommonRoll, prepareCombatRoll, preparePsychicPowerRoll } from "./dialog.js";
 import { commonRoll, combatRoll } from "./roll.js";
 
+// Import Helpers
+import * as chat from "./chat.js";
+
 Hooks.once("init", () => {
     CONFIG.Combat.initiative = { formula: "@initiative.base + @initiative.bonus", decimals: 0 };
     CONFIG.Actor.entityClass = DarkHeresyActor;
@@ -88,3 +91,10 @@ Hooks.on("preCreateActor", (createData) => {
         createData.token.actorLink = true;
     }
 });
+
+
+/* -------------------------------------------- */
+/*  Other Hooks                                 */
+/* -------------------------------------------- */
+
+Hooks.on("getChatLogEntryContext", chat.addChatMessageContextOptions);

--- a/template/chat/critical.html
+++ b/template/chat/critical.html
@@ -1,0 +1,10 @@
+<div class='dark-heresy chat roll'>
+    <div class='background border'>
+        <h1>Critical Rolls</h3>
+            <ul style="text-align: left; display: inline-block;">
+                {{#each rolls}}
+                <li>{{critNumber}} {{damageTypeLong type}}</li>
+                {{/each}}
+            </ul>
+    </div>
+</div>

--- a/template/chat/roll.html
+++ b/template/chat/roll.html
@@ -30,8 +30,8 @@
         {{/if}}
         {{/if}}
         {{#each damages as |damage|}}
-            <h3 class="separator damage-location">{{localize location}}</h3>
-            <p><strong>{{localize "CHAT.DAMAGE"}}:</strong> <span class="damage-total">{{damage.total}}</span> <strong>{{damageType damageType}}</strong></p>
+            <h3 class="separator damage-location" data-location={{location}}>{{localize location}}</h3>
+            <p><strong>{{localize "CHAT.DAMAGE"}}:</strong> <span class="damage-total">{{damage.total}}</span> <strong class="damage-type">{{damageType damageType}}</strong></p>
             <p><strong>{{localize "CHAT.PENETRATION"}}:</strong> <span class="damage-penetration">{{penetration}}</span></p>
             {{#if damage.righteousFury}}
             <p><strong>{{localize "CHAT.RIGHTEOUS_FURY"}}:</strong> <span class="damage-righteous-fury">{{damage.righteousFury}}</span></p>

--- a/template/chat/roll.html
+++ b/template/chat/roll.html
@@ -30,11 +30,11 @@
         {{/if}}
         {{/if}}
         {{#each damages as |damage|}}
-            <h3 class="separator">{{localize location}}</h3>
-            <p><strong>{{localize "CHAT.DAMAGE"}}:</strong> {{damage.total}} <strong>{{damageType ../damageType}}</strong></p>
-            <p><strong>{{localize "CHAT.PENETRATION"}}:</strong> {{penetration}}</p>
+            <h3 class="separator damage-location">{{localize location}}</h3>
+            <p><strong>{{localize "CHAT.DAMAGE"}}:</strong> <span class="damage-total">{{damage.total}}</span> <strong>{{damageType damageType}}</strong></p>
+            <p><strong>{{localize "CHAT.PENETRATION"}}:</strong> <span class="damage-penetration">{{penetration}}</span></p>
             {{#if damage.righteousFury}}
-            <p><strong>{{localize "CHAT.RIGHTEOUS_FURY"}}:</strong> {{damage.righteousFury}}</p>
+            <p><strong>{{localize "CHAT.RIGHTEOUS_FURY"}}:</strong> <span class="damage-righteous-fury">{{damage.righteousFury}}</span></p>
             {{/if}}
         {{/each}}
     </div>


### PR DESCRIPTION
# Adds apply damage macro to damage rolls
- Takes into account the area hit on the roll.
- Takes into account the armour and toughness for that location.
- Applies multiple hits for auto fire.
- Displays the results of critical damage in the chat window with the damage type. You can then look up the critical effect in the relevant table.
- Handles righteous fury.
- Applies the damage to the selected target i.e. select a target and then click apply damage and it will apply the wounds to that character.

# Image of the macro
![image](https://user-images.githubusercontent.com/5542588/109416375-c2d96280-79b5-11eb-8fd7-7796f7a71f96.png)
# Image of critical damage
![image](https://user-images.githubusercontent.com/5542588/109416382-d1c01500-79b5-11eb-91c1-2a7e2c3ef0fb.png)

### Notes
I've done my best to take into account all the damage rules but I am not the most experienced with the system or with foundry. I added this over Christmas when our group got together for a game but haven't touched it much since. Very open to any suggestions and comments!