### PR TITLE
Improved labels and details on the applied damage macro

### DIFF
--- a/template/chat/critical.html
+++ b/template/chat/critical.html
@@ -1,10 +1,13 @@
 <div class='dark-heresy chat roll'>
     <div class='background border'>
-        <h1>Critical Rolls</h3>
-            <ul style="text-align: left; display: inline-block;">
-                {{#each rolls}}
-                <li>{{critNumber}} {{damageTypeLong type}}</li>
-                {{/each}}
-            </ul>
+        <h1>Applied Damage to: </h1>
+        <h3>{{target}}</h3>
+        <ul style="text-align: left; display: inline-block;">
+            {{#each rolls}}
+            <li>{{appliedDmg}} {{damageTypeLong type}} as {{source}} </li>
+            {{/each}}
+        </ul>
+        <br>
+        <div>Current <b>Wounds: </b>{{totalWounds}}. <b>Critical Damage: </b>{{totalCritWounds}}</div>
     </div>
 </div>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/27952699/109439560-189e2100-7a2f-11eb-881f-0bb34d82fece.png)

Improvement suggestion to the PR created by @Silver292 : https://github.com/moo-man/DarkHeresy2E-FoundryVTT/pull/34

As show in the image above, this PR improves the detail level of the "applied damage" by:

* Fixed broken HTML tags
* Showing the Targeted token name
* Damage values are "applied damage" and not total
* Shown total accumulated damage at the end of the chat message, separated from "recently" applied damage
* Explained type of damage (Wounds, Critical, Righteous Fury)