### PR TITLE
Substracts ammo when making attack rolls from a ranged weapon

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -158,6 +158,7 @@
 
   "DIALOG.CUSTOM_ROLL": "Custom Roll",
   "DIALOG.ROLL_WITH": "Roll With",
+  "DIALOG.CLIP": "Ammo Left",
   "DIALOG.TARGET": "Target",
   "DIALOG.BONUS": "Bonus",
   "DIALOG.MODIFIER": "Modifier",

--- a/lang/es.json
+++ b/lang/es.json
@@ -147,6 +147,7 @@
 
   "DIALOG.CUSTOM_ROLL": "Tirada personalizada",
   "DIALOG.TARGET": "Objetivo",
+  "DIALOG.CLIP": "Munición Restante",
   "DIALOG.BONUS": "Bonus",
   "DIALOG.MODIFIER": "Modificador",
   "DIALOG.DAMAGE": "Daño",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -154,6 +154,7 @@
   
     "DIALOG.CUSTOM_ROLL": "Lancer personnalisé",
     "DIALOG.ROLL_WITH": "Lancer avec",
+    "DIALOG.CLIP": "Munitions restantes",
     "DIALOG.TARGET": "Cible",
     "DIALOG.BONUS": "Bonus",
     "DIALOG.MODIFIER": "Modificateur",

--- a/script/common/roll.js
+++ b/script/common/roll.js
@@ -13,6 +13,10 @@ export async function combatRoll(rollData) {
     await _sendToChat(rollData);
 }
 
+export async function reportEmptyClip(rollData) {
+    await _emptyClipToChat(rollData);
+}
+
 function _computeTarget(rollData) {
     const range = (rollData.range) ? rollData.range : "0";
     let attackType = 0;
@@ -225,5 +229,19 @@ async function _sendToChat(rollData) {
     } else if (chatData.rollMode === "selfroll") {
         chatData.whisper = [game.user];
     }
+    ChatMessage.create(chatData);
+}
+
+async function _emptyClipToChat(rollData) {
+    let chatData = {
+        user: game.user._id,
+        content: `
+          <div class="dark-heresy chat roll">
+              <div class="background border">
+                  <p><strong>Reload! Out of Ammo!</strong></p>
+              </div>
+          </div>
+        `
+    };
     ChatMessage.create(chatData);
 }

--- a/script/sheet/actor/actor.js
+++ b/script/sheet/actor/actor.js
@@ -174,11 +174,13 @@ export class DarkHeresySheet extends ActorSheet {
       rateOfFire = {burst: weapon.data.data.rateOfFire.burst, full: weapon.data.data.rateOfFire.full};
     }
     let rollData = {
+      wid: weapon.id,
       name: weapon.name,
       baseTarget: characteristic.total + weapon.data.data.attack,
       modifier: 0,
       isMelee: weapon.data.data.class === "melee",
       isRange: !(weapon.data.data.class === "melee"),
+      clip: weapon.data.data.clip,
       damageFormula: weapon.data.data.damage,
       damageBonus: (weapon.data.data.class === "melee") ? this.actor.data.data.characteristics.strength.bonus : 0,
       damageType: weapon.data.data.damageType,
@@ -187,7 +189,7 @@ export class DarkHeresySheet extends ActorSheet {
       special: weapon.data.data.special,
       psy: {value: this.actor.data.data.psy.rating, display: false},
     };
-    await prepareCombatRoll(rollData);
+    await prepareCombatRoll(rollData, this.actor);
   }
 
   async _prepareRollPsychicPower(event) {

--- a/template/dialog/combat-roll.html
+++ b/template/dialog/combat-roll.html
@@ -77,8 +77,12 @@
     <div>
         {{#if isRange}}
             <div class="wrapper">
-                <label>{{localize "DIALOG.CLIP"}}: </label>
-                <div>{{clip.value}}</div>
+                <table>
+                <tr>
+                <td style="padding:0 10px 0 10px;"><b>{{localize "DIALOG.CLIP"}}: </b>{{clip.value}}</td>
+                <td style="padding:0 10px 0 10px;"><b>RoF: </b>1/{{#if rateOfFire.burst}}{{rateOfFire.burst}}{{else}}-{{/if}}/{{#if rateOfFire.full}}{{rateOfFire.full}}{{else}}-{{/if}}</td>
+                </tr>
+                </table>
             </div>
         {{/if}}
     </div>

--- a/template/dialog/combat-roll.html
+++ b/template/dialog/combat-roll.html
@@ -74,6 +74,14 @@
             <input id="penetration" type="text" value="{{penetrationFormula}}" />
         </div>
     </div>
+    <div>
+        {{#if isRange}}
+            <div class="wrapper">
+                <label>{{localize "DIALOG.CLIP"}}: </label>
+                <div>{{clip.value}}</div>
+            </div>
+        {{/if}}
+    </div>
 </div>
 <script>
     $(".wrapper input").focusin(function () {


### PR DESCRIPTION
- Shows ammo left and RoF when attacking with a ranged weapon:
![image](https://user-images.githubusercontent.com/27952699/110442935-aa56ff80-80bb-11eb-8600-3e8c8fcd21c1.png)
- When attacking with any Attack Type other than None (i.e. Standard, Semi Auto, etc), clip size will be substracted by the amount defined on the Rate of Fire properties of the weapon for that attack type
- If no ammo is enough to make the attack, the attack roll will be cancelled and a Chat message will be submitted instead:
![image](https://user-images.githubusercontent.com/27952699/110412606-c2fbf100-808c-11eb-85b5-1aaef60f1250.png)
- The Clip size is immediately updated on the character sheet
- Reloading must be done manual (in a way of ensuring players do what they think is right and check according gear)
- If a given weapon is missing Rate of fire or has a value of 0, then no ammo will be substracted at all
- Does not affect Melee Weapons

Any feedback welcome!