### PR TITLE
Register setting for default token display

### DIFF
--- a/script/common/hooks.js
+++ b/script/common/hooks.js
@@ -71,6 +71,22 @@ Hooks.once("init", () => {
         default: 0,
         type: Number,
     });
+    game.settings.register("dark-heresy", "defaultTokenDisplay", {
+        name: "Default token name display mode",
+        hint: "Choose default behavior on hovering on token names.",
+        scope: "world",
+        config: true,
+        type: String,
+        default: CONST.TOKEN_DISPLAY_MODES.OWNER_HOVER,
+        choices: {
+          [CONST.TOKEN_DISPLAY_MODES.NONE]: "Never Displayed",
+          [CONST.TOKEN_DISPLAY_MODES.CONTROL]: "When Controlled",
+          [CONST.TOKEN_DISPLAY_MODES.OWNER_HOVER]: "Hovered by Owner",
+          [CONST.TOKEN_DISPLAY_MODES.HOVER]: "Hovered by Anyone",
+          [CONST.TOKEN_DISPLAY_MODES.OWNER]: "Always for Owner",
+          [CONST.TOKEN_DISPLAY_MODES.ALWAYS]: "Always for Everyone"
+        }
+    });
 });
 
 Hooks.once("ready", () => {
@@ -81,7 +97,7 @@ Hooks.on("preCreateActor", (createData) => {
     mergeObject(createData, {
         "token.bar1" :{ "attribute" : "wounds" },
         "token.bar2" :{ "attribute" : "fatigue" },
-        "token.displayName" : CONST.TOKEN_DISPLAY_MODES.HOVER,
+        "token.displayName" : game.settings.get('dark-heresy', 'defaultTokenDisplay'),
         "token.displayBars" : CONST.TOKEN_DISPLAY_MODES.ALWAYS,
         "token.disposition" : CONST.TOKEN_DISPOSITIONS.NEUTRAL,
         "token.name" : createData.name


### PR DESCRIPTION
Token display was so far hardcoded into all tokens as "Hover by All". This caused various inconveniences to me. The default is metagame potential, so I made this configurable but also default to "Hover by owner"

Disclaimer: Won't modify any existing tokens.

![image](https://user-images.githubusercontent.com/27952699/110695558-56970400-81ea-11eb-85be-6bd239bda62c.png)
