### PR TITLE
Fix a typo with new weapon "type" field on the weapon sheet

### DIFF
--- a/template/sheet/weapon.html
+++ b/template/sheet/weapon.html
@@ -39,7 +39,7 @@
                         </select>
                     </div>
 					<div class="stat type">
-                        <select name="data.ype">
+                        <select name="data.type">
                             {{#select data.type}}
                                 <option value="las">{{localize "WEAPON.LAS"}}</option>
                                 <option value="solidprojectile">{{localize "WEAPON.SOLIDPROJECTILE"}}</option>


### PR DESCRIPTION
This prevents being able to set the weapon type on a weapon