### PR TITLE
add unlink ammo, allow multiple ammo to be linked

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -179,6 +179,7 @@
     "DIALOG.DAMAGE": "Damage",
     "DIALOG.TYPE": "Type",
     "DIALOG.PENETRATION": "Penetration",
+    "DIALOG.AMMO": "Ammunition",
     "DIALOG.PSY_RATING": "Psy Rating",
     "DIALOG.RANGE": "Range",
     "DIALOG.ATTACK_TYPE": "Attack Type",

--- a/script/common/dialog.js
+++ b/script/common/dialog.js
@@ -59,7 +59,7 @@ export async function prepareCommonRoll(rollData) {
  * @param {DarkHeresyActor} actorRef
  */
 export async function prepareCombatRoll(rollData, actorRef) {
-    if (rollData.weapon.isRanged && rollData.weapon.clip.value <= 0) {
+    if (rollData.weapon.isRange && rollData.weapon.clip.value <= 0) {
         reportEmptyClip(rollData);
     } else {
         const html = await renderTemplate("systems/dark-heresy/template/dialog/combat-roll.hbs", rollData);
@@ -100,10 +100,12 @@ export async function prepareCombatRoll(rollData, actorRef) {
                             rollData.aim.val += 10;
                         }
 
-                        rollData.weapon.damageFormula = html.find("#damageFormula")[0].value.replace(" ", "");
+                        let ammo = actorRef.items.get(html.find("#ammo")[0]?.value);
+
+                        rollData.weapon.damageFormula = `${html.find("#damageFormula")[0].value.replace(" ", "")} + ${ammo?.system.effect.damage.modifier ?? ""}`;
                         rollData.weapon.damageType = html.find("#damageType")[0].value;
                         rollData.weapon.damageBonus = parseInt(html.find("#damageBonus")[0].value, 10);
-                        rollData.weapon.penetrationFormula = html.find("#penetration")[0].value;
+                        rollData.weapon.penetrationFormula = `${html.find("#penetration")[0].value} + ${ammo?.system.effect.damage.modifier ?? ""}`;
                         rollData.flags.isDamageRoll = false;
                         rollData.flags.isCombatRoll = true;
 

--- a/script/common/util.js
+++ b/script/common/util.js
@@ -64,8 +64,9 @@ export default class DarkHeresyUtil {
             clip: weaponItem.clip,
             rateOfFire: rateOfFire,
             range: !isMelee ? weaponItem.range : 0,
-            damageFormula: weaponItem.damage + attributeMod + (weaponTraits.force ? "+PR" : "") + (weaponItem.system.ammoItem ? `+${weaponItem.system.ammoItem.system.effect.damage.modifier}` : ""),
-            penetrationFormula: weaponItem.penetration + (weaponTraits.force ? "+PR" : "") + (weaponItem.system.ammoItem ? `+${weaponItem.system.ammoItem.system.effect.penetration}` : ""),
+            damageFormula: weaponItem.damage + attributeMod + (weaponTraits.force ? "+PR" : ""),
+            penetrationFormula: weaponItem.penetration + (weaponTraits.force ? "+PR" : ""),
+            ammos: weaponItem.system.ammoItems,
             traits: weaponTraits,
             special: weaponItem.special
         });

--- a/script/data/item/ammunitionData.js
+++ b/script/data/item/ammunitionData.js
@@ -38,9 +38,9 @@ export default class AmmunitionData extends EquipmentItemData {
     prepareWeaponFetch() {
         // We only store a reference to the weapon, here we get the whole item and store it in memory only
         // Weapons can only be connected to ammo for actor owned ammo
-        if (this.parent.actor && this.weaponId !== "") {
+        if (this.parent.actor && this.weaponId && this.weaponId !== "") {
             this.weaponItem = this.parent.actor.items.get(this.weaponId);
-            this.weapon = this.weaponItem.name;
+            this.weapon = this.weaponItem?.name ?? "";
         }
 
         if (this.parent.actor && this.weaponId === "") {
@@ -57,7 +57,8 @@ export default class AmmunitionData extends EquipmentItemData {
     }
 
     static migrateDamageModifier(source) {
-        source.effect.damage.modifier = parseInt(source.effect.damage?.modifier) || 0;
+        if (source.effect?.damage) {
+            source.effect.damage.modifier = parseInt(source.effect.damage?.modifier) || 0;
+        }
     }
-
 }

--- a/script/data/item/weaponData.js
+++ b/script/data/item/weaponData.js
@@ -28,7 +28,7 @@ export default class WeaponData extends EquipmentItemData {
             reload: new fields.StringField({ initial: "Full" }),
             special: new fields.StringField({ initial: "" }),
             attack: new fields.NumberField({ initial: 0 }),
-            ammo: new fields.StringField({ initial: "" })
+            ammo: new fields.ArrayField(new fields.StringField({ blank: false}))
         };
 
     }
@@ -43,8 +43,9 @@ export default class WeaponData extends EquipmentItemData {
     prepareAmmoFetch() {
         // We only store a reference to the ammo, here we get the whole item and store it in memory only
         // Ammo can only be connected to weapons for actor owned weapons
-        if (this.parent.actor && this.ammo !== "") {
-            this.ammoItem = this.parent.actor.items.get(this.ammo);
+        if (this.parent.actor && this.ammo.length > 0) {
+            this.ammoItems = [];
+            this.ammo.forEach(ammo => this.ammoItems.push(this.parent.actor.items.get(ammo)));
         }
     }
 

--- a/script/sheet/actor/actor.js
+++ b/script/sheet/actor/actor.js
@@ -7,6 +7,7 @@ export class DarkHeresySheet extends ActorSheet {
         html.find(".item-create").click(ev => this._onItemCreate(ev));
         html.find(".item-edit").click(ev => this._onItemEdit(ev));
         html.find(".item-delete").click(ev => this._onItemDelete(ev));
+        html.find(".ammo-unlink").click(ev => this._onAmmoUnlink(ev));
         html.find(".roll-characteristic").click(async ev => await this._prepareRollCharacteristic(ev));
         html.find(".roll-skill").click(async ev => await this._prepareRollSkill(ev));
         html.find(".roll-speciality").click(async ev => await this._prepareRollSpeciality(ev));
@@ -22,7 +23,7 @@ export class DarkHeresySheet extends ActorSheet {
         data.system = data.data.system;
         data.items = this.constructItemLists(data);
         data.enrichment = await this._enrichment();
-        data.effects = this.prepareActiveEffectCategories();
+        // data.effects = this.prepareActiveEffectCategories();
         return data;
     }
 
@@ -83,6 +84,16 @@ export class DarkHeresySheet extends ActorSheet {
         const div = $(event.currentTarget).parents(".item");
         this.actor.deleteEmbeddedDocuments("Item", [div.data("itemId")]);
         div.slideUp(200, () => this.render(false));
+    }
+
+    _onAmmoUnlink(event) {
+        event.preventDefault();
+        const ammoId = $(event.currentTarget).parents(".linked-item").data("ammoId");
+        const weaponId = $(event.currentTarget).parents(".item").data("itemId");
+
+        let newAmmos = this.actor.items.get(weaponId).system.ammo.filter(ammo => ammo !== ammoId);
+        this.actor.items.get(weaponId).update({ "system.ammo": newAmmos });
+        this.actor.items.get(ammoId).update({ "system.weaponId": "" });
     }
 
     async _prepareCustomRoll() {

--- a/script/sheet/weapon.js
+++ b/script/sheet/weapon.js
@@ -44,13 +44,10 @@ export class WeaponSheet extends DarkHeresyItemSheet {
 
         // It has to be ammunition from the same actor
         if (item?.type === "ammunition" && item?.actor.uuid === this.item.actor.uuid) {
-            if (this.item.system.ammo !== "") {
-                let oldAmmo = this.item.actor.items.get(this.item.system.ammo);
-                oldAmmo.update({ "system.weaponId": "" });
-            }
-
             item.update({ "system.weaponId": this.item.id });
-            this.item.update({ "system.ammo": item.id });
+            let newAmmos = new Set(this.item.system.ammo);
+            newAmmos.add(item.id);
+            this.item.update({ "system.ammo": newAmmos });
         }
     }
 }

--- a/template/dialog/combat-roll.hbs
+++ b/template/dialog/combat-roll.hbs
@@ -1,14 +1,14 @@
 <div class="dark-heresy dialog">
-    <div class="flex row wrap background border" style="flex-basis: 100%;margin-bottom: 5px">        
+    <div class="flex row wrap background border" style="flex-basis: 100%;margin-bottom: 5px">
         <h1>{{localize name}}</h1>
         {{#unless weapon.traits.skipAttackRoll}}
             <div class="wrapper">
                 <label>{{localize "DIALOG.TARGET"}}</label>
-                <input id="target" type="number" value="{{target.base}}" data-dtype="Number"/>
+                <input id="target" type="number" value="{{target.base}}" data-dtype="Number" />
             </div>
             <div class="wrapper">
                 <label>{{localize "DIALOG.MODIFIER"}}</label>
-                <input id="modifier" type="text" value="{{target.modifier}}"/>
+                <input id="modifier" type="text" value="{{target.modifier}}" />
             </div>
             <div class="wrapper">
                 <label>{{localize "DIALOG.AIM"}}</label>
@@ -17,32 +17,32 @@
                 </select>
             </div>
             {{#if weapon.isMelee}}
-            <div class="wrapper">
-                <label>{{localize "DIALOG.ATTACK_TYPE"}}</label>
-                <select id="attackType">
-                    {{selectOptions (config "attackTypeMelee") selected=attackType localize=true}}
-                </select>
-            </div>
+                <div class="wrapper">
+                    <label>{{localize "DIALOG.ATTACK_TYPE"}}</label>
+                    <select id="attackType">
+                        {{selectOptions (config "attackTypeMelee") selected=attackType localize=true}}
+                    </select>
+                </div>
             {{/if}}
             {{#if weapon.isRange}}
-            <div class="wrapper">
-                <label>{{localize "DIALOG.RANGE"}}</label>
-                <select id="range">
-                    {{selectOptions (config "ranges") selected=rangeMod localize=true}}
-                </select>
-            </div>
-            <div class="wrapper">
-                <label>{{localize "DIALOG.ATTACK_TYPE"}}</label>
-                <select id="attackType">
-                    {{selectOptions (config "attackTypeRanged") selected=attackType.name localize=true}}
-                </select>
-            </div>
+                <div class="wrapper">
+                    <label>{{localize "DIALOG.RANGE"}}</label>
+                    <select id="range">
+                        {{selectOptions (config "ranges") selected=rangeMod localize=true}}
+                    </select>
+                </div>
+                <div class="wrapper">
+                    <label>{{localize "DIALOG.ATTACK_TYPE"}}</label>
+                    <select id="attackType">
+                        {{selectOptions (config "attackTypeRanged") selected=attackType.name localize=true}}
+                    </select>
+                </div>
             {{/if}}
             <div class="separator"></div>
         {{/unless}}
         <div class="wrapper">
             <label>{{localize "DIALOG.DAMAGE"}}</label>
-            <input id="damageFormula" type="text" value="{{weapon.damageFormula}}"/>
+            <input id="damageFormula" type="text" value="{{weapon.damageFormula}}" />
         </div>
         <div class="wrapper">
             <label>{{localize "DIALOG.TYPE"}}</label>
@@ -52,21 +52,31 @@
         </div>
         <div class="wrapper">
             <label>{{localize "DIALOG.BONUS"}}</label>
-            <input id="damageBonus" type="number" value="{{weapon.damageBonus}}" data-dtype="Number"/>
+            <input id="damageBonus" type="number" value="{{weapon.damageBonus}}" data-dtype="Number" />
         </div>
         <div class="wrapper">
             <label>{{localize "DIALOG.PENETRATION"}}</label>
             <input id="penetration" type="text" value="{{weapon.penetrationFormula}}" />
         </div>
+        {{#if weapon.ammos}}
+            <div class="wrapper">
+                <label>{{localize "DIALOG.AMMO"}}</label>
+                <select id="ammo">
+                    {{selectOptions weapon.ammos valueAttr="id" nameAttr="name" labelAttr="name"}}
+                </select>
+            </div>
+        {{/if}}
     </div>
     <div>
         {{#if weapon.isRange}}
             <div class="wrapper">
                 <table>
-                <tr>
-                <td style="padding:0 10px 0 10px;"><b>{{localize "DIALOG.CLIP"}}: </b>{{weapon.clip.value}}</td>
-                <td style="padding:0 10px 0 10px;"><b>RoF: </b>1/{{#if weapon.rateOfFire.burst}}{{weapon.rateOfFire.burst}}{{else}}-{{/if}}/{{#if weapon.rateOfFire.full}}{{weapon.rateOfFire.full}}{{else}}-{{/if}}</td>
-                </tr>
+                    <tr>
+                        <td style="padding:0 10px 0 10px;"><b>{{localize "DIALOG.CLIP"}}: </b>{{weapon.clip.value}}</td>
+                        <td style="padding:0 10px 0 10px;"><b>RoF:
+                            </b>1/{{#if weapon.rateOfFire.burst}}{{weapon.rateOfFire.burst}}{{else}}-{{/if}}/{{#if weapon.rateOfFire.full}}{{weapon.rateOfFire.full}}{{else}}-{{/if}}
+                        </td>
+                    </tr>
                 </table>
             </div>
         {{/if}}

--- a/template/sheet/actor/tab/gear.hbs
+++ b/template/sheet/actor/tab/gear.hbs
@@ -46,11 +46,15 @@
                                         class="fas fa-trash"></i></a>
                             </div>
                         </div>
-                        {{#if item.system.ammoItem}}
-                            <div class="linked-item">
-                                &#8627 {{item.system.ammoItem.name}}
+                        {{#each item.system.ammoItems as |ammo|}}
+                            <div class="linked-item flex row" data-ammo-id="{{ammo.id}}">
+                                &#8627 {{ammo.name}}
+                                <div class="button">
+                                    <a class="item-control ammo-unlink" title="Unlink Ammo"><i
+                                            class="fas fa-chain-broken"></i></a>
+                                </div>
                             </div>
-                        {{/if}}
+                        {{/each}}
                     </div>
                 {{/each}}
             </div>


### PR DESCRIPTION
From your wishlist this does:

- Allow more than one Ammo-Type per Weapon (Fireselector, QoL)
- Add a Delete Button on the Ammo to Remove the Linkage
- Add a Drop Down for the Ammo in Combat Dialog of Ranged Weapons => these checks for the existence of ammo, so you can use ammo to fake melee modes